### PR TITLE
Update questionable usage of camelCase

### DIFF
--- a/content/manual/operators/define-struct.md
+++ b/content/manual/operators/define-struct.md
@@ -19,7 +19,7 @@ weight: 70
 - Toplevel form to define a new struct-like data type.
 - Structs are useful when named fields are clearer than positional fields of `define-type`.
 - A field named `f` is accessed with the operator `.f`.
-- A struct name is conventionally written in CamelCase.
+- A struct name is conventionally written in PascalCase.
 
 ## Example
 


### PR DESCRIPTION
camelCase with a capitalized first letter is more idiomatically referred to as PascalCase